### PR TITLE
Docs for 0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Devstep
 
-Dead simple, no frills development environment builder that leverages
-[Docker](https://www.docker.io/) and the [buildpack](https://devcenter.heroku.com/articles/buildpacks)
-abstraction for fast and easy provisioning of project dependencies.
+A dead simple, no frills development environment builder that is based around a
+simple goal:
 
-See http://fgrehm.viewdocs.io/devstep or the project's [/docs](/docs) folder
-for more information.
+> I want to `git clone` and run a single command to hack on any software project.
+
+For more information please check http://fgrehm.viewdocs.io/devstep

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,238 @@
+# Getting Started
+-----------------
+
+Devstep comes in two flavors, you can either use the provided CLI or you can build
+on top of the provided images from `Dockerfile`s.
+
+Regardless of the flavor you choose, it is a good idea to `docker pull fgrehm/devstep:v0.0.1`
+before creating your first container / image for a better "user experience".
+Docker will download that image as needed but by pulling it first you'll reduce
+the waiting time when interacting with Devstep for the first time.
+
+## Sanity check
+---------------
+
+This project is being developed and tested on an Ubuntu 14.04 host with Docker
+1.0.0+, while it is likely to work on other distros / Docker versions /
+[boot2docker](http://boot2docker.io/), I'm not sure how it will behave on the wild.
+
+## Using the CLI
+----------------
+
+Before you try out the CLI, make sure you have Docker installed and that your
+user is capable to run `docker` commands [without `sudo`](http://docs.docker.io/installation/ubuntulinux/#giving-non-root-access).
+
+> **IMPORTANT**: The `developer` user that is used by Devstep assumes your user
+and group ids are equal to `1000` when using the CLI or the container's init
+process will be aborted. This is to guarantee that files created within Docker
+containers have the appropriate permissions so that you can manipulate them
+on the host without the need to use `sudo`. This is currently a Devstep limitation
+that will be worked around in case there is enough demand or will be fixed once
+Docker adds support for user namespaces ([#6600](https://github.com/dotcloud/docker/pull/6600)
+/ [#6602](https://github.com/dotcloud/docker/pull/6602) / [#6603](https://github.com/dotcloud/docker/pull/6603)
+/ [#4572](https://github.com/dotcloud/docker/pull/4572)).
+
+> The `1000` id was chosen because it is the default uid / gid of Ubuntu Desktop users
+that are created during the installation process. To work around this limitation,
+please build your own image using the appropriate ids and add a `DEVSTEP_SOURCE_IMAGE=<YOUR-IMAGE>`
+line to your `~/.devsteprc`.
+
+To install the CLI, you can run the one liner below and read on for more:
+
+```sh
+L=$HOME/bin/devstep && curl -sL https://github.com/fgrehm/devstep/raw/master/devstep > $L && chmod +x $L
+```
+
+_The snippet above assumes `$HOME/bin` is on your PATH, please change `$HOME/bin`
+to an appropriate path in case your system is not configured like that._
+
+### `devstep hack`
+
+This is the easiest way to get started with Devstep. By running the command
+from your project's root, Devstep will:
+
+1. Create a Docker container based on `fgrehm/devstep` with project sources bind
+   mounted at `/workspace`.
+2. Detect and install project's dependencies on the new container using the
+   available buildpacks.
+3. Start a `bash` session with everything in place for you to do your work.
+
+Once you `exit` the `bash` session, the container will be garbage collected
+(aka `docker rm`ed).
+
+In case you need to provide additional parameters to the underlying `docker run`
+command you can use the `-r` flag. For example, `devstep hack -r "-p 80:8080"` will
+redirect the `8080` port on your host to the port `80` within the container.
+
+### `devstep build`
+
+By running the command from your project's root, Devstep will:
+
+1. Create a Docker container based on `fgrehm/devstep` with project sources bind
+   mounted at `/workspace`.
+2. Detect and install project's dependencies on the new container using the
+   available buildpacks.
+3. `docker commit` the container to a `devstep/<PROJECT>:<TIMESTAMP>` image.
+4. `docker tag` the new image as `devstep/<PROJECT>:latest`.
+
+The `devstep/<PROJECT>` images act like snapshots of your project dependencies
+and will be used as the source image for subsequent `devstep` commands instead
+of the `fgrehm/devstep` image.
+
+For example, running a `devstep hack` after building the image will use `devstep/<PROJECT>:latest`
+as the base container for new "hacking sessions" so that you don't have to build
+your project's environment from scratch. The same applies for a new `devstep build`,
+which will build on top of the latest image reducing the overall build time when
+compared to reconfiguring the environment from scratch using
+`Dockerfile`s.
+
+Because the `build` command bind mounts your project sources on the Docker container
+during the configuration process, you'll have to provide the full path to sources
+on the host machine as a Docker volume in order to work on the project.
+`devstep hack` can take care of that for you or you can manually:
+
+```sh
+docker run -ti -v `pwd`:/workspace devstep/<PROJECT>
+```
+
+### Bootstrapping a new project (AKA solving the chicken or the egg problem)
+
+Assuming you are willing to use Docker / Devstep to avoid cluttering your machine
+with development tools, there's no point on installing Ruby / Python / ... on your
+computer in order to scaffold a new project. To make that process easier, you can
+use the `devstep bootstrap` command.
+
+That command will start an interactive `bash` session with the current directory
+bind mounted as `/workspace` on the container and you'll be able to manually
+install packages / tools required to scaffold your new project. You can even
+force a specific buildpack to run from there.
+
+For example, scaffolding a new Rails project means:
+
+```sh
+cd $HOME/projects # or whatever directory you keep your projects
+devstep bootstrap -w my_app
+
+build-project -b ruby
+source $HOME/load-env.sh
+gem install rails
+rails new my_app
+
+exit # Or do some extra setup before exiting
+```
+
+Once you `exit` the container, you should end up with a `devstep/my_app` image
+and a brand new Rails app under `$HOME/projects/my_app` on your machine. To
+abort the bootstrap process, just `exit 1` from within the container and answer
+'No' when asked for confirmation for commiting the image.
+
+As with `devstep build`, subsequent `devstep` commands like `build` and `hack`
+will use `devstep/my_app:latest` as the source image. Project sources
+also won't get stored inside the Docker image and you'll need to provide the
+full path to its sources on the host machine as a Docker volume in order to
+work on the project. `devstep hack` can take care of that for you or you can
+manually:
+
+```sh
+docker run -ti -v `pwd`:/workspace devstep/<PROJECT>
+```
+
+To bootstrap projects for other platforms and frameworks you can follow a similar
+approach, replacing the Ruby / Rails specifics with the platform / framework
+of choice.
+
+### Caching project's dependencies packages on the host
+
+As mentioned on the [introduction](introduction) section, Devstep is also capable
+of reducing disk space and initial configuration times by caching packages on the
+host using a strategy similar to [vagrant-cachier's cache buckets](http://fgrehm.viewdocs.io/vagrant-cachier/how-does-it-work).
+This behavior is enabled by default and will be further documented on the future.
+For now you need to know that the `/tmp/devstep/cache` dir on the host will be bind
+mounted to containers created by the CLI under `/.devstep/cache` and most of your
+project's dependencies packages will be downloaded to there. Note that the dependencies
+themselves are extracted and kept inside the images built by the CLI and you can
+safely clean things up or disable the caching behavior at will.
+
+To disable the caching functionality you can add the `DEVSTEP_CACHE_PATH=""`
+line to your `~/.devsteprc`.
+
+### Other commands
+
+* `clean` -> Remove all images built for the current project
+* `pristine` -> Rebuild current project associated Docker image from scratch
+* `run` -> Run a one off command against the current source image
+* `images` -> Display images available for the current project
+* `ps` -> List all containers associated with the current project
+* `info` -> Show some information about the current project
+
+For the most up-to-date list of supported commands, run `devstep --help`.
+
+
+## Building images using `Dockerfiles`
+--------------------------------------
+
+In case your project require additional stuff to work you can use the provided
+`fgrehm/devstep`, `fgrehm/devstep-ab` or `fgrehm/devstep-sa` images as a starting
+point for your `Dockerfile`s.
+
+The `fgrehm/devstep` image is the base image used for Devstep environments and
+requires you to manually trigger the build:
+
+```Dockerfile
+FROM fgrehm/devstep:v0.0.1
+
+# Add project to the image and build it
+ADD . /workspace
+WORKDIR /workspace
+RUN CLEANUP=1 /.devstep/bin/build-project /workspace
+```
+
+To make things easier, there's also a `fgrehm/devstep-ab:v0.0.1` image that
+does the same steps as outlined above automatically for you by leveraging `ONBUILD`
+instructions, trimming down your `Dockerfile` to a single line:
+
+```Dockerfile
+FROM fgrehm/devstep-ab:v0.0.1
+```
+
+And in case you want to run extra services (like a DB) within the same container
+of your project, you can use the `fgrehm/devstep-sa` image:
+
+```Dockerfile
+FROM fgrehm/devstep-sa:v0.0.1
+
+# Add project to the image and build it
+ADD . /workspace
+WORKDIR /workspace
+RUN CLEANUP=1 /.devstep/bin/build-project /workspace
+
+# Configure PostgreSQL and Redis to run on the project's container
+RUN /.devstep/bin/configure-addons postgresql redis
+```
+
+By using a `Dockerfile` to build your images (instead of using `devstep build`)
+you'll be able to skip mounting project's sources on the container when running
+it and a simple `docker run -it <IMAGE-NAME>` should do the trick. **_Keep in mind
+that changes made to project sources will be kept inside the container and
+you'll lose them when you `docker rm` it._**
+
+
+## Available buildpacks
+-----------------------
+
+* [Bats](https://github.com/fgrehm/devstep/tree/master/buildpacks/bats)
+* [Golang](https://github.com/fgrehm/devstep/tree/master/buildpacks/golang)
+* [Inline](https://github.com/fgrehm/devstep/tree/master/buildpacks/inline)
+* [NodeJS](https://github.com/fgrehm/devstep/tree/master/buildpacks/nodejs)
+* [PHP](https://github.com/fgrehm/devstep/tree/master/buildpacks/php)
+* [Python](https://github.com/fgrehm/devstep/tree/master/buildpacks/python)
+* [Ruby](https://github.com/fgrehm/devstep/tree/master/buildpacks/ruby)
+
+
+## More information
+-------------------
+
+If you reached this point it means you should have a good understanding of how
+Devstep works and what you can do with it. If you are still wondering how you can
+use the tool and / or benefit from it, please create a [new issue](https://github.com/fgrehm/devstep/issues/new)
+so that we can discuss how can we improve the docs :)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,93 +1,36 @@
 # Devstep
 
-Devstep is a dead simple, no frills development environment builder that is based
-around a simple goal:
+A dead simple, no frills development environment builder that is based around a
+simple goal:
 
 > I want to `git clone` and run a single command to hack on any software project.
 
-To accomplish that, Devstep comes with a CLI that uses a "self suficient"
-[Docker](https://www.docker.io/) image and the [buildpack](https://devcenter.heroku.com/articles/buildpacks)
-abstraction for fast and easy provisioning of project dependencies.
+[Devstep demo on Vimeo](https://vimeo.com/99482658)
 
-## WAT?!?
+<br>
 
-Have you ever deployed an app to a platform like Heroku? How awesome it is to
-`git push` some code and see it running without worrying about the infrastructure
-it is going to run on? Now imagine that idea applied to any type of project,
-regardless of whether they are web apps or not. This is what I'm trying to achieve
-with Devstep.
+## WAT?!
 
-Be it a CLI tool, a plugin for some framework or a web app, I don't care, I just
-want "someone" to do the heavy lifting of preparing an isolated and disposable
-environment using as close to "zero configuration" as possible so that I can
-focus on writing and delivering working software :-)
+Yeah, just give Devstep your code and let it take care of the rest (including
+automatic port forwarding to linked containers). Check out this demo of using
+Devstep with [Discourse]():
 
+[Discourse demo on Vimeo](http://vimeo.com/99212562)
 
-## Why should I use it?
+<br>
 
-You can configure a Docker base image yourself using a `Dockerfile`, so why bother
-using Devstep?
+And before I forget, Devstep is not just for the web, it is also suitable for building
+/ developing libraries and CLI tools:
 
-Because configuring a base system from scratch to hack on a project (using Docker
-or not) is not an easy task for many people. Devstep's base image alleviates that
-pain by providing an environment [similar to Heroku's](https://github.com/progrium/cedarish)
-and should be capable of building and running a wide range of applications / tools
-/ libraries (given there is a buildpack for the platform being used of course).
+[Sidekiq demo on Vimeo](https://vimeo.com/99487410)
 
-Devstep is also capable of reducing the disk space and initial configuration times by
-(optionally) caching packages on host using a strategy similar to [vagrant-cachier's cache buckets](http://fgrehm.viewdocs.io/vagrant-cachier/how-does-it-work),
-allowing you to even build images while offline.
-
-## Ok, so how does it work?
-
-Devstep is a Docker image builder that takes your app's source as an input and
-produces a Docker image with all dependencies required for hacking on it. You
-can use Devstep in two different ways (from `Dockerfile`s or from the provided
-Bash CLI) and you are free to manually run the images or use other tools to manage
-your containers at runtime.
-
-For quick hacks, there is a `devstep hack` command that will create a new
-container, install everything that is needed for your project and will fire up
-a bash session for some hacking. Once you `exit` it, it will be garbage collected
-(aka `docker rm`ed).
-
-
-## What's on the [Docker image](https://index.docker.io/u/fgrehm/devstep)?
-
-Same packages installed by [`progrium/cedarish`](https://github.com/progrium/cedarish)
-(we use it as a base image) plus [some other stuff](Dockerfile), an init script
-based on [`phusion/baseimage-docker`](https://github.com/phusion/baseimage-docker)'s
-and [some buildpacks](https://github.com/fgrehm/devstep/tree/master/buildpacks).
-
-
-## Why standard Heroku buildpacks are not used?
-
-Because development environments have a few different needs than production
-environments and not all projects are web apps. For example, PHP apps are likely
-to have [opcache](http://www.php.net/manual/en/intro.opcache.php) enabled
-on production to improve app's performance but have it disabled during development
-and Ruby on Rails apps might require assets to be precompiled.
-
+If you are just getting started with Devstep, check out the [introduction](introduction)
+and the [getting started](getting-started) guides.
 
 ## Project status
 
-This is mostly the result of many different hacks that suit my own needs and
-seem to be working fine based on my [limited testing](https://github.com/fgrehm/devstep-examples).
-Use at your own risk and expect things to break. Also, don't get scared by some bad code you might see
-around as it will be cleaned up in case more people think this project is useful ;)
-
-
-## Installing the CLI
-
-Assuming `$HOME/bin` is on your path, you can run the one liner below to install
-the [`devstep`](/devstep) script:
-
-```sh
-L=$HOME/bin/devstep && curl -sL https://github.com/fgrehm/devstep/raw/master/devstep > $L && chmod +x $L
-```
-
-
-## :warning: Work in progress :warning:
-
-_Documentation is being worked on, stay tunned for updates or have a look at
-project sources if you are feeling adventurous_
+This is mostly the result of many different hacks that suits my needs for developing
+Ruby on Rails and Go CLI apps. It has been working fine for my use cases since April /
+March 2014 and it also seems to play really well with other platforms based on my
+[limited testing](https://github.com/fgrehm/devstep-examples). Use at your own risk
+and expect things to break (and if it does break [please let me know!](https://github.com/fgrehm/devstep/issues/new)).

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,0 +1,78 @@
+# Introduction
+--------------
+
+Have you ever deployed an app to a platform like Heroku? How awesome it is to
+`git push` some code and see it running without worrying about the infrastructure
+it is going to run on? Now imagine that idea applied to any type of project,
+regardless of whether they are web apps or not. This is what I'm trying to achieve
+with Devstep.
+
+At Devstep's heart, there is a "self suficient" [Docker](https://www.docker.io/)
+image that leverages the [buildpack](https://devcenter.heroku.com/articles/buildpacks)
+abstraction for automatic detection and installation of project dependencies. The
+base image comes with a script that that takes your app's source as an input and
+installs everything that is required for hacking on it.
+
+Be it a CLI tool, a plugin for some framework or a web app, I don't care, I just
+want "someone" to do the heavy lifting of preparing an isolated and disposable
+environment using as close to "zero configuration" as possible so that I can
+focus on writing and delivering working software :-)
+
+
+## Why should I use it?
+
+You can configure a Docker base image yourself using a `Dockerfile`, so why bother
+using Devstep?
+
+Configuring a base system from scratch to hack on a project (using Docker or not)
+is not an easy task for many people. Yes, there are plenty of platform specific
+images available for download on [Docker Hub](https://hub.docker.com/) but because
+Devstep's base image provides an environment that is [similar to Heroku's](https://github.com/progrium/cedarish),
+it should be capable of building and running a wide range of applications / tools
+/ libraries.
+
+Devstep is also capable of reducing the disk space and initial configuration times by
+(optionally) caching packages on the host machine using a strategy similar to [vagrant-cachier's cache buckets](http://fgrehm.viewdocs.io/vagrant-cachier/how-does-it-work),
+allowing you to even build some images while offline.
+
+
+## How can I use it?
+
+Devstep can be used to build development environments in at least two different
+ways: from `Dockerfile`s or from the provided Bash CLI. To run the images built,
+you are free to `docker run` them by hand, use other tools (like [Fig](http://orchardup.github.io/fig/))
+or use the provided `devstep hack` command.
+
+
+## What's included on the base [Docker image](https://registry.hub.docker.com/u/fgrehm/devstep/)?
+
+We use [`progrium/cedarish`](https://github.com/progrium/cedarish) as the base
+image, so everything that gets installed by it will be available on `fgrehm/devstep`
+images.
+
+On top of `progrium/cedarish`, we:
+
+* Create a `developer` user to avoid using `root` and creating files with wrong permissions during development.
+* Install some extra devel packages (like `libreadline6-dev` and `libyaml-dev`) and
+  "nice to have" packages and utilities (like `vim`, `htop` and [`jq`](http://stedolan.github.io/jq/)).
+* Configure PostgreSQL and MySQL clients.
+* Set the image `ENTRYPOINT` to our own init system and the default command to a `bash` login shell.
+* Configure a couple of startup scripts (like automatic port forwading to linked containers).
+* And add the supported [buildpacks](https://github.com/fgrehm/devstep/tree/master/buildpacks).
+
+_For more information please have a look at the [Dockerfile](https://github.com/fgrehm/devstep/blob/master/Dockerfile)._
+
+
+## Why standard Heroku buildpacks are not used?
+
+Because development environments have a few different needs than production
+environments and not all projects are web apps. For example, PHP apps are likely
+to have [opcache](http://www.php.net/manual/en/intro.opcache.php) enabled
+on production to improve app's performance but have it disabled during development
+and it is a good practice to have Ruby on Rails assets precompiled on production.
+But I tried my best to stay as close as possible to the official buildpacks.
+
+--------------------------------------------
+
+That's it for a brief introduction, from here you can have a look at the [getting started](getting-started)
+guide for a quick start on how to use Devstep.

--- a/docs/template.html
+++ b/docs/template.html
@@ -48,6 +48,32 @@
       th {
         padding: 10px;
       }
+
+      /* https://gist.github.com/jgarber/2302238 */
+      .flex-video {
+        position: relative;
+        padding-top: 25px;
+        padding-bottom: 67.5%;
+        height: 0;
+        margin-bottom: 16px;
+        overflow: hidden;
+      }
+
+      .flex-video.widescreen { padding-bottom: 57.25%; }
+      .flex-video.vimeo { padding-top: 0; }
+
+      .flex-video iframe,
+      .flex-video object,
+      .flex-video embed {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+      @media only screen and (max-device-width: 800px), only screen and (device-width: 1024px) and (device-height: 600px), only screen and (width: 1280px) and (orientation: landscape), only screen and (device-width: 800px), only screen and (max-width: 767px) {
+        .flex-video { padding-top: 0; }
+      }
     </style>
 
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
@@ -69,6 +95,14 @@
             </button>
           </div>
           <div class="navbar-collapse collapse" id="navbar-main">
+            <ul class="nav navbar-nav">
+              <li>
+                <a href="introduction">Introduction</a>
+              </li>
+              <li>
+                <a href="getting-started">Getting started</a>
+              </li>
+            </ul>
             <ul class="nav navbar-nav navbar-right visible-md visible-lg">
               <li><iframe src="http://ghbtns.com/github-btn.html?user={{USER}}&repo={{NAME}}&type=watch&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe></li>
               <li><iframe src="http://ghbtns.com/github-btn.html?user={{USER}}&repo={{NAME}}&type=fork&count=true" allowtransparency="true" frameborder="0" scrolling="0" width="95" height="20"></iframe></li>
@@ -95,15 +129,26 @@
 
     <script src="//oss.maxcdn.com/libs/jquery/2.0.3/jquery.min.js"></script>
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
-    <!--
+    <script>
+      (function($) {
+        $('a[href*="vimeo"]').each(function() {
+          var $this  = $(this);
+          var url    = $this.prop('href').split('/');
+          var id     = url[url.length - 1];
+
+          var iframe = '<iframe src="//player.vimeo.com/video/' + id + '" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>';
+          iframe = '<div class="row"><div class="col-md-6 col-md-offset-3"><div class="flex-video widescreen">' + iframe + '</div></div></div>';
+          $this.parent().replaceWith(iframe);
+        });
+      })(jQuery);
+    </script>
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-      ga('create', 'UA-38687494-5', 'viewdocs.io');
+      ga('create', 'UA-38687494-8', 'auto');
       ga('send', 'pageview');
     </script>
-    -->
   </body>
 </html>


### PR DESCRIPTION
This is a squash of 17 commits:
- docs: Initial introduction and getting started
- Moar docs
- A bit more docs
- Update introduction.md
- Update getting-started.md
- Update project status
- More work on docs
- Add link to docker issues / PRs related to user namespaces
- docs: Note that Im testing it on Docker 1.0.1+
- docs: A couple tweaks to the home page
- Update README
- docs: Mention `rake db:create db:migrate` on discourse example so that I dont forget it when recording the video
- Puma default port is 9292
- docs: `--standalone` is not a real flag
- docs: Sidekiq changed `rake spec` to `rake test`
- docs: Getting close to enough docs for v0.0.1
- Done with docs for v0.0.1
