### PR TITLE
POSTGRESQL_DATA custom data dir should also be injected in PG configuration file

### DIFF
--- a/addons/postgresql/bin/start-server
+++ b/addons/postgresql/bin/start-server
@@ -11,7 +11,7 @@ POSTGRESQL_DATA=${POSTGRESQL_DATA:-"/shared/postgresql"}
 POSTGRESQL_BIN=/usr/lib/postgresql/9.3/bin/postgres
 POSTGRESQL_CONFIG_FILE=/etc/postgresql/9.3/main/postgresql.conf
 
-sed -i 's|\/shared\/postgresql|'$POSTGRESQL_DATA'|g' $POSTGRESQL_CONFIG_FILE
+sudo sed -i 's|\/shared\/postgresql|'$POSTGRESQL_DATA'|g' $POSTGRESQL_CONFIG_FILE
 
 if [ ! -d $POSTGRESQL_DATA ] || [ ! -f $POSTGRESQL_DATA/PG_VERSION ]; then
   sudo mkdir -p $POSTGRESQL_DATA


### PR DESCRIPTION
Configurable postgresql data directory was all the rage with https://github.com/fgrehm/devstep/pull/73
but without also injecting this custom directory inside Postgresql configuration before starting it was simply not working.

an error like that was happening if you set something different than the default value:

```
2014-09-05 19:39:17 UTC FATAL:  data directory "/shared/postgresql" does not exist
```

Sorry, I didn't catch that before because I was fixing that without remembering it in my base image. But now I tested well it really works with this patch.

<!---
@huboard:{"order":75.0,"milestone_order":79,"custom_state":""}
-->
