### PR TITLE
FIX broken configuration of addons postgresql

### DIFF
--- a/stack/addons/postgresql/bin/configure
+++ b/stack/addons/postgresql/bin/configure
@@ -4,7 +4,7 @@ set -e            # fail fast
 set -o pipefail   # dont ignore exit codes when piping output
 # set -x          # enable debugging
 
-if ! [ -f /etc/init.d/postgresql ]; then
+if ! [ -f /usr/lib/postgresql/9.3/bin/postgresql ]; then
   echo "-----> [postgres] Installing server"
   (
     sudo apt-get update -q &&


### PR DESCRIPTION
Hi Fabio
Since this commit https://github.com/progrium/cedarish/commit/f7b704c825e7982ae8efef4193436c902477c650#diff-758d2e7de1a14d48254071e97e87ef0dR46 
in cedar postgresql-server-dev is installed in the images

This package have for dependency postgresql-common : the https://packages.debian.org/fr/sid/postgresql-server-dev-9.3
And postgresql-common will create the file "/etc/init.d/postgresql".
This file is used for detecting if postgresql-server is installed, but it's wrong we should test an other file like /usr/lib/postgresql/9.3/bin/postgresql

Thanks for devstep
