### PR TITLE
[FIX] If we do not want to have a broken installation of node we need to install the "nodejs-legacy"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN DEBIAN_FRONTEND=noninteractive && \
     apt-get update && \
     apt-get install -y libreadline5 libmcrypt4 libffi-dev --no-install-recommends && \
     apt-get install -y postgresql-client mysql-client libsqlite3-dev --no-install-recommends && \
-    apt-get install -y --force-yes vim htop tmux mercurial bzr nodejs libssl0.9.8 --no-install-recommends && \
+    apt-get install -y --force-yes vim htop tmux mercurial bzr nodejs-legacy libssl0.9.8 --no-install-recommends && \
     apt-get install -y software-properties-common bash-completion --no-install-recommends && \
     echo "[client]\nprotocol=tcp\nuser=root" >> $HOME/.my.cnf && \
     echo "export PGHOST=localhost" >> $HOME/.profile.d/postgresql.sh && \


### PR DESCRIPTION
Indeed due to incompatibility between package the nodejs package create a bin called "nodejs" instead of "node" this broke the installation of yeoman for example. Using legacy version create a symlink to nodejs and fix this issue. More information here : http://stackoverflow.com/questions/21168141/can-not-install-packages-using-node-package-manager-in-ubuntu