### PR TITLE
Fix redis addon

### DIFF
--- a/docs/addons/docker.md
+++ b/docs/addons/docker.md
@@ -11,3 +11,12 @@ To install it you can run `configure-addons docker` from within the container.
 
 To specify a Docker version, use the the `DEVSTEP_DOCKER_VERSION` environmental
 variable.
+
+Keep in mind that if you run the command from the container add-on won't be available
+on next `hack` run. To make the addon persistent add the following line to the
+`devstep.yml` file in the project root:
+
+```yml
+provision:
+  - ['configure-addons', 'docker']
+```

--- a/docs/addons/heroku-toolbelt.md
+++ b/docs/addons/heroku-toolbelt.md
@@ -4,4 +4,13 @@
 This addon will install the latest [Heroku Toolbelt](https://toolbelt.heroku.com/)
 version available for the Ubuntu 14.04 release.
 
-To install it you can run `configure-addons oracle-java-8` from within the container.
+To install it you can run `configure-addons heroku-toolbelt` from within the container.
+
+Keep in mind that if you run the command from the container add-on won't be available
+on next `hack` run. To make the addon persistent add the following line to the
+`devstep.yml` file in the project root:
+
+```yml
+provision:
+  - ['configure-addons', 'heroku-toolbelt']
+```

--- a/docs/addons/memcached.md
+++ b/docs/addons/memcached.md
@@ -6,3 +6,12 @@ release and it will set things up in a way that it is automatically started alon
 with your containers.
 
 To install it you can run `configure-addons memcached` from within the container.
+
+Keep in mind that if you run the command from the container add-on won't be available
+on next `hack` run. To make the addon persistent add the following line to the
+`devstep.yml` file in the project root:
+
+```yml
+provision:
+  - ['configure-addons', 'memcached']
+```

--- a/docs/addons/oracle-java.md
+++ b/docs/addons/oracle-java.md
@@ -6,3 +6,12 @@ and will leverage Devstep's caching mechanism so that the downloaded files are
 reused between environments.
 
 To install it you can run `configure-addons oracle-java-8` from within the container.
+
+Keep in mind that if you run the command from the container add-on won't be available
+on next `hack` run. To make the addon persistent add the following line to the
+`devstep.yml` file in the project root:
+
+```yml
+provision:
+  - ['configure-addons', 'oracle-java-8']
+```

--- a/docs/addons/postgresql.md
+++ b/docs/addons/postgresql.md
@@ -6,3 +6,12 @@ release and it will set things up in a way that it is automatically started alon
 with your containers.
 
 To install it you can run `configure-addons postgresql` from within the container.
+
+Keep in mind that if you run the command from the container add-on won't be available
+on next `hack` run. To make the addon persistent add the following line to the
+`devstep.yml` file in the project root:
+
+```yml
+provision:
+  - ['configure-addons', 'postgresql']
+```

--- a/docs/addons/redis.md
+++ b/docs/addons/redis.md
@@ -6,3 +6,12 @@ release and it will set things up in a way that it is automatically started alon
 with your containers.
 
 To install it you can run `configure-addons redis` from within the container.
+
+Keep in mind that if you run the command from the container add-on won't be available
+on next `hack` run. To make the addon persistent add the following line to the
+`devstep.yml` file in the project root:
+
+```yml
+provision:
+  - ['configure-addons', 'redis']
+```

--- a/stack/addons/redis/bin/configure
+++ b/stack/addons/redis/bin/configure
@@ -11,7 +11,7 @@ if ! $(which redis-server &> /dev/null); then
     sudo apt-get update -q &&
     sudo apt-get install redis-server -y --force-yes -q
   ) &>> /tmp/configure-redis.log && \
-    rm /tmp-configure-redis.log
+    rm /tmp/configure-redis.log
 fi
 
 addon_basedir="$( cd -P "$( dirname "$0" )" && pwd )"


### PR DESCRIPTION
This commit fixes the typo in redis addon installation; the typo prevented from starting the `redis-server`.

I've also updated `add-ons` to include info about custom provisioning - if you `configure-addon` from the container add-on won't be available on the next `hack` run. There was also typo in `heroku-toolbelt` command which I've fixed as well.
